### PR TITLE
fix path of resume in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Erick Dolores
+# Erick Dolores Resume
 
 Complete resume below:
 
-![Resume](Erick_Dolores_Colored_Resume.pdf)
+![Resume](https://github.com/edolores/resume-latex-source/blob/master/Erick_Dolores_Colored_Resume.pdf?raw=true)
 
 This resume was built using a LaTeX template built by Byungjin Park. The link is here: https://github.com/posquit0/Awesome-CV.
 


### PR DESCRIPTION
added a raw link to the readme for the resume pdf instead of a directory reference.